### PR TITLE
Add homebrew and rubyfmt set up to CI script

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,8 +29,7 @@ jobs:
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,10 +19,10 @@ permissions:
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v3
@@ -34,5 +34,10 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+    - name: Set up rubyfmt
+      run: brew install rubyfmt
     - name: Run tests
       run: bundle exec rake test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  x86_64-darwin-20
 
 DEPENDENCIES
   bundler (~> 2.4.2)


### PR DESCRIPTION
This merge request adds homebrew set up and rubyfmt set up, since it's core dependency of the app but it wasn't clear how to do that in a Github actions context. 

I found this with a bit of Googling https://github.com/Homebrew/actions/tree/master/setup-homebrew which looks like a good start. 