### PR TITLE
Add RuboCop to CI script

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,5 +38,7 @@ jobs:
       uses: Homebrew/actions/setup-homebrew@master
     - name: Set up rubyfmt
       run: brew install rubyfmt
+    - name: Run RuboCop
+      run: bundle exec rubocop --parallel
     - name: Run tests
       run: bundle exec rake test


### PR DESCRIPTION
So we don't have to worry about RuboCop changes slipping through and making it onto the `main` branch!