### PR TITLE
Update homepage value in gemspec file

### DIFF
--- a/ruby-lsp-rubyfmt.gemspec
+++ b/ruby-lsp-rubyfmt.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary = "Ruby LSP rubyfmt"
   spec.description = "An addon for the Ruby LSP that enables formatting with rubyfmt"
-  spec.homepage = "http://mygemserver.com"
+  spec.homepage = "https://github.com/jscharf/ruby-lsp-rubyfmt"
   spec.license = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'


### PR DESCRIPTION
The homepage value was set to a placeholder so this changes it to the main Github page for this repository.