### PR TITLE
feat: update code to work with ruby-lsp-0.17.1

### DIFF
--- a/lib/ruby_lsp/ruby-lsp-rubyfmt/addon.rb
+++ b/lib/ruby_lsp/ruby-lsp-rubyfmt/addon.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "open3"
+require "singleton"
 
 module RubyLsp
   module RubyLspRubyfmt
@@ -10,11 +11,11 @@ module RubyLsp
         "Ruby Fmt Formatter"
       end
 
-      def activate
+      def activate(global_state, message_queue)
         # The first argument is an identifier users can pick to select this formatter. To use this formatter, users must
         # have rubyLsp.formatter configured to "rubyfmt"
         # The second argument is a singleton instance that implements the `FormatterRunner` interface (see below)
-        RubyLsp::Requests::Formatting.register_formatter("rubyfmt", RubyFmtFormatterRunner.instance)
+        global_state.register_formatter("rubyfmt", RubyFmtFormatterRunner.instance)
       end
 
       def deactivate
@@ -26,7 +27,7 @@ module RubyLsp
       # Make it a singleton class
       include Singleton
       # If using Sorbet to develop the addon, then include this interface to make sure the class is properly implemented
-      include RubyLsp::Requests::Support::FormatterRunner
+      include RubyLsp::Requests::Support::Formatter
 
       # Use the initialize method to perform any sort of ahead of time work.
       # For example, reading configurations for yourformatter since they are unlikely to change between requests
@@ -36,7 +37,7 @@ module RubyLsp
       # The main part of the interface is implementing the run method.
       # It receives the URI and the document being formatted.
       # IMPORTANT: This method must return the formatted document source without mutating the original one in document
-      def run(uri, document)
+      def run_formatting(uri, document)
         output, _status = Open3.capture2("rubyfmt", stdin_data: document.source)
         output
       end

--- a/test/ruby/lsp/rubyfmt_test.rb
+++ b/test/ruby/lsp/rubyfmt_test.rb
@@ -19,7 +19,7 @@ module RubyLsp
           end
         RUBY
 
-        output = RubyLspRubyfmt::RubyFmtFormatterRunner.instance.run("", doc)
+        output = RubyLspRubyfmt::RubyFmtFormatterRunner.instance.run_formatting("", doc)
 
         assert_equal(<<~RUBY, output)
           class Foo


### PR DESCRIPTION
- Update formatter runner to implement RubyLsp::Requests::Support::Formatter interface, implementing `run_formatting`
- Update to register addon with global state, similar to the built-in Rubocop formatter in `ruby-lsp`
- This allows the addon to work with version 0.17.1 of ruby-lsp, the latest version of ruby-lsp at time of writing